### PR TITLE
[IT-2768] Update role name for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     secrets: inherit
     with:
       CONTEXT: dev
-      ROLE_TO_ASSUME: arn:aws:iam::634210816736:role/sagebase-github-oidc-sage-ProviderRoledccvalidator-RGZWZ8IMAUCX
+      ROLE_TO_ASSUME: arn:aws:iam::634210816736:role/sagebase-github-oidc-sage-bionetworks-dccvalidator-1kD-infra
 
   cdk-deploy-prod:
     if: ${{github.ref == 'refs/heads/prod'}}
@@ -53,4 +53,4 @@ jobs:
     secrets: inherit
     with:
       CONTEXT: prod
-      ROLE_TO_ASSUME: arn:aws:iam::593604776210:role/sagebase-github-oidc-sage-ProviderRoledccvalidator-16AFP3D1Z0F07
+      ROLE_TO_ASSUME: arn:aws:iam::593604776210:role/sagebase-github-oidc-sage-bionetworks-dccvalidator-1kD-infra


### PR DESCRIPTION
The CI role names to assume will change due to PR
Sage-Bionetworks-IT/organizations-infra#859. update to the new role names

depends on Sage-Bionetworks-IT/organizations-infra#859

